### PR TITLE
test: remove -g flag (verify sequential builds work without debug symbols)

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -72,7 +72,7 @@ JOBS ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/de
 
 # Compiler flags
 COMMON_FLAGS ?= -w
-DEBUG_FLAGS ?= $(COMMON_FLAGS) -g  # -g required for Linux builds
+DEBUG_FLAGS ?= $(COMMON_FLAGS)  # Testing: -g removed (was needed for parallel builds?)
 RELEASE_FLAGS ?= $(COMMON_FLAGS) -r -O3pz
 BUILD_MODE ?= debug
 


### PR DESCRIPTION
## Testing Hypothesis

The `-g` debug symbols flag may have been required due to **parallel builds** causing race conditions, not a Linux compiler requirement.

## What This Tests

Removes the `-g` flag from `DEBUG_FLAGS` to see if sequential builds (no `-j`) work without it.

## Expected Outcomes

**If CI passes ✅:**
- The `-g` flag was only needed for parallel builds
- We can simplify the build flags
- Debug symbols only needed when explicitly requested

**If CI fails ❌:**
- The `-g` flag is truly required on Linux
- Keep the flag with updated documentation
- Close PR and revert change

## No Risk

This is a test branch. If it fails, we simply don't merge it.