### PR TITLE
Add simple Flappy Bird gameplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-# Garmin Hello World App
+# Mini Flappy for Garmin
 
-A simple Hello World application for Garmin smartwatches using the Connect IQ platform.
+A lightweight Flappy Bird-inspired game for Garmin smartwatches built with the Connect IQ platform.
 
 ![20E82F67-CFDA-4BEC-B904-C16F8ACCB0BF](https://github.com/user-attachments/assets/71851cea-1c31-49b8-97d1-54f9af331be9)
 
 ## Overview
 
-This is a basic Connect IQ watch app that displays "Hello World!" on your Garmin watch. It's designed as a starting point for learning Connect IQ development and includes a complete build chain.
+Steer a tiny bird through an endless stream of pipes using the watch's select button or touch screen. The project is intentionally simple so you can see how to structure a mini-game in Monkey C while still shipping with a complete build chain.
 
 ## Features
 
-- ✅ Simple "Hello World" display
+- ✅ One-button/tap gameplay that mimics Flappy Bird
+- ✅ Lightweight game loop that runs entirely inside a single view
 - ✅ Works on Forerunner 265, Fenix 7, Epix 2, and Venu 2
 - ✅ Proper Connect IQ project structure
 - ✅ Build scripts for easy compilation
@@ -104,12 +105,12 @@ garmin_hello_world/
 
 ## Next Steps
 
-After running the Hello World app:
+After playing a few rounds:
 
-1. Modify the message in `resources/strings/strings.xml`
-2. Update the UI in `source/views/MainView.mc`
-3. Add new features by extending the delegate and view classes
-4. Read WARP.md for comprehensive development guidance
+1. Tweak physics constants in `source/views/MainView.mc` to change the game's difficulty.
+2. Replace the simple graphics with sprite sheets or vector art using the `resources/drawables/` folder.
+3. Expand the game loop with bonus pickups, high score persistence, or vibration feedback in `MainDelegate.mc`.
+4. Read WARP.md for comprehensive development guidance.
 
 ## Resources
 

--- a/resources/layouts/layout.xml
+++ b/resources/layouts/layout.xml
@@ -1,3 +1,3 @@
 <layout id="MainLayout">
-    <label id="label" text="@Strings.HelloWorld" x="center" y="center" font="Gfx.FONT_LARGE" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+    <label id="label" text="@Strings.TapToFlap" x="center" y="center" font="Gfx.FONT_LARGE" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
 </layout>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -1,4 +1,6 @@
 <strings>
-    <string id="AppName">Hello World</string>
-    <string id="HelloWorld">Hello World!</string>
+    <string id="AppName">Mini Flappy</string>
+    <string id="GameOver">Game Over</string>
+    <string id="RestartPrompt">Press select to restart</string>
+    <string id="TapToFlap">Tap or press select to flap</string>
 </strings>

--- a/source/App.mc
+++ b/source/App.mc
@@ -17,7 +17,8 @@ class HelloWorldApp extends App.AppBase {
 
     // Return the initial view of your application here
     function getInitialView() {
-        return [ new HelloWorldView(), new HelloWorldDelegate() ];
+        var view = new HelloWorldView();
+        return [ view, new HelloWorldDelegate(view) ];
     }
 
 }

--- a/source/MainDelegate.mc
+++ b/source/MainDelegate.mc
@@ -3,7 +3,10 @@ using Toybox.System as Sys;
 
 class HelloWorldDelegate extends Ui.BehaviorDelegate {
 
-    function initialize() {
+    var view;
+
+    function initialize(viewInstance) {
+        view = viewInstance;
         BehaviorDelegate.initialize();
     }
 
@@ -16,7 +19,9 @@ class HelloWorldDelegate extends Ui.BehaviorDelegate {
 
     // Handle the select/enter button press
     function onSelect() {
-        Sys.println("Select button pressed");
+        if (view != null) {
+            view.handleInput();
+        }
         return true;
     }
 

--- a/source/views/MainView.mc
+++ b/source/views/MainView.mc
@@ -1,51 +1,235 @@
 using Toybox.WatchUi as Ui;
 using Toybox.Graphics as Gfx;
-using Toybox.System as Sys;
+using Toybox.Math as Math;
 
 class HelloWorldView extends Ui.View {
+
+    const GAP_OFFSETS = [ -40, -15, 15, -25, 25, 5, -5, 35 ];
+
+    var viewWidth;
+    var viewHeight;
+
+    var birdX;
+    var birdY;
+    var birdRadius = 10;
+    var birdVelocity;
+
+    var gravity = 0.8;
+    var jumpVelocity = -7.5;
+
+    var pipeX;
+    var pipeWidth = 28;
+    var pipeGapY;
+    var pipeGapHeight = 90;
+    var pipeSpeed = 3;
+    var gapIndex = 0;
+
+    var score = 0;
+    var isGameOver = false;
+    var needsReset = true;
+    var hasStarted = false;
 
     function initialize() {
         View.initialize();
     }
 
-    // Load your resources here
-    function onLayout(dc) {
-        setLayout(Rez.Layouts.MainLayout(dc));
-    }
-
-    // Called when this View is brought to the foreground. Restore
-    // the state of this View and prepare it to be shown. This includes
-    // loading resources into memory.
     function onShow() {
+        needsReset = true;
+        Ui.requestUpdate();
     }
 
-    // Update the view
     function onUpdate(dc) {
-        // Call the parent onUpdate function to redraw the layout
-        View.onUpdate(dc);
-        
-        // Draw Hello World text in the center of the screen
-        dc.setColor(Gfx.COLOR_WHITE, Gfx.COLOR_BLACK);
+        updateDimensions(dc);
+
+        if (needsReset) {
+            resetGame();
+            needsReset = false;
+        }
+
+        if (!isGameOver) {
+            updateGameState();
+        }
+
+        drawScene(dc);
+
+        if (!isGameOver) {
+            Ui.requestUpdate();
+        }
+    }
+
+    function handleInput() {
+        if (isGameOver) {
+            resetGame();
+            Ui.requestUpdate();
+            return;
+        }
+
+        hasStarted = true;
+        birdVelocity = jumpVelocity;
+        Ui.requestUpdate();
+    }
+
+    function onTap(position) {
+        handleInput();
+        return true;
+    }
+
+    function updateDimensions(dc) {
+        if (viewWidth == null) {
+            viewWidth = dc.getWidth();
+        }
+
+        if (viewHeight == null) {
+            viewHeight = dc.getHeight();
+        }
+    }
+
+    function resetGame() {
+        birdX = viewWidth / 4;
+        birdY = viewHeight / 2;
+        birdVelocity = 0;
+
+        pipeX = viewWidth + pipeWidth;
+        pipeSpeed = Math.max(2, viewWidth / 120.0);
+        pipeGapHeight = Math.max(60, Math.min(viewHeight * 0.55, 90));
+        gapIndex = 0;
+        pipeGapY = nextGapCenter();
+
+        score = 0;
+        isGameOver = false;
+        hasStarted = false;
+    }
+
+    function updateGameState() {
+        if (!hasStarted) {
+            return;
+        }
+
+        birdVelocity += gravity;
+        birdY += birdVelocity;
+
+        pipeX -= pipeSpeed;
+
+        if (pipeX + pipeWidth < 0) {
+            pipeX = viewWidth + pipeWidth;
+            pipeGapY = nextGapCenter();
+            score += 1;
+        }
+
+        if (birdY - birdRadius < 0) {
+            birdY = birdRadius;
+            isGameOver = true;
+            return;
+        } else if (birdY + birdRadius > viewHeight) {
+            birdY = viewHeight - birdRadius;
+            isGameOver = true;
+            return;
+        }
+
+        var halfGap = pipeGapHeight / 2;
+        var withinPipeX = (birdX + birdRadius) > pipeX && (birdX - birdRadius) < (pipeX + pipeWidth);
+
+        if (withinPipeX) {
+            if ((birdY - birdRadius) < (pipeGapY - halfGap) || (birdY + birdRadius) > (pipeGapY + halfGap)) {
+                isGameOver = true;
+            }
+        }
+    }
+
+    function drawScene(dc) {
+        dc.setColor(Gfx.COLOR_BLACK, Gfx.COLOR_BLACK);
         dc.clear();
-        
-        var width = dc.getWidth();
-        var height = dc.getHeight();
-        var message = Ui.loadResource(Rez.Strings.HelloWorld);
-        
+
+        drawPipes(dc);
+        drawBird(dc);
+        drawScore(dc);
+
+        if (isGameOver) {
+            drawGameOver(dc);
+        } else if (!hasStarted) {
+            drawInstructions(dc);
+        }
+    }
+
+    function drawPipes(dc) {
+        var halfGap = pipeGapHeight / 2;
+        var topPipeHeight = pipeGapY - halfGap;
+        var bottomPipeY = pipeGapY + halfGap;
+
+        var pipeXPos = Math.round(pipeX);
+        var topHeight = Math.max(0, Math.round(topPipeHeight));
+        var bottomY = Math.round(bottomPipeY);
+        var bottomHeight = Math.max(0, viewHeight - bottomY);
+
+        dc.setColor(Gfx.COLOR_GREEN, Gfx.COLOR_BLACK);
+        dc.fillRectangle(pipeXPos, 0, pipeWidth, topHeight);
+        dc.fillRectangle(pipeXPos, bottomY, pipeWidth, bottomHeight);
+    }
+
+    function drawBird(dc) {
+        dc.setColor(Gfx.COLOR_YELLOW, Gfx.COLOR_BLACK);
+        dc.fillCircle(Math.round(birdX), Math.round(birdY), birdRadius);
+    }
+
+    function drawScore(dc) {
         dc.setColor(Gfx.COLOR_WHITE, Gfx.COLOR_TRANSPARENT);
+        var scoreText = "Score: " + score;
         dc.drawText(
-            width / 2,
-            height / 2,
-            Gfx.FONT_LARGE,
-            message,
+            viewWidth / 2,
+            20,
+            Gfx.FONT_SMALL,
+            scoreText,
             Gfx.TEXT_JUSTIFY_CENTER | Gfx.TEXT_JUSTIFY_VCENTER
         );
     }
 
-    // Called when this View is removed from the screen. Save the
-    // state of this View here. This includes freeing resources from
-    // memory.
-    function onHide() {
+    function drawGameOver(dc) {
+        dc.setColor(Gfx.COLOR_WHITE, Gfx.COLOR_TRANSPARENT);
+        dc.drawText(
+            viewWidth / 2,
+            viewHeight / 2 - 12,
+            Gfx.FONT_MEDIUM,
+            Ui.loadResource(Rez.Strings.GameOver),
+            Gfx.TEXT_JUSTIFY_CENTER | Gfx.TEXT_JUSTIFY_VCENTER
+        );
+
+        dc.drawText(
+            viewWidth / 2,
+            viewHeight / 2 + 18,
+            Gfx.FONT_SMALL,
+            Ui.loadResource(Rez.Strings.RestartPrompt),
+            Gfx.TEXT_JUSTIFY_CENTER | Gfx.TEXT_JUSTIFY_VCENTER
+        );
+    }
+
+    function drawInstructions(dc) {
+        dc.setColor(Gfx.COLOR_WHITE, Gfx.COLOR_TRANSPARENT);
+        dc.drawText(
+            viewWidth / 2,
+            viewHeight / 2,
+            Gfx.FONT_SMALL,
+            Ui.loadResource(Rez.Strings.TapToFlap),
+            Gfx.TEXT_JUSTIFY_CENTER | Gfx.TEXT_JUSTIFY_VCENTER
+        );
+    }
+
+    function nextGapCenter() {
+        var offset = GAP_OFFSETS[gapIndex];
+        gapIndex = (gapIndex + 1) % GAP_OFFSETS.size();
+
+        var halfGap = pipeGapHeight / 2;
+        var minY = halfGap + 10;
+        var maxY = viewHeight - halfGap - 10;
+
+        var target = viewHeight / 2 + offset;
+
+        if (target < minY) {
+            target = minY;
+        } else if (target > maxY) {
+            target = maxY;
+        }
+
+        return target;
     }
 
 }


### PR DESCRIPTION
## Summary
- replace the hello world sample with a tap-to-flap mini-game that keeps a looping game state inside the main view
- add new resources and layout messaging for the flappy-style experience and update the README to describe the gameplay
- wire the behavior delegate to forward button presses to the view so players can restart or flap

## Testing
- Not run (Connect IQ SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2ecd8875883328ee02e46e1a8eb51