### PR TITLE
Ensure build workflow runs on PR updates

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types:
+      # Run when the PR is opened, updated with new commits, or re-opened
+      - opened
+      - synchronize
+      - reopened
 
 env:
   # SDK Version Strategy:


### PR DESCRIPTION
## Summary
- ensure the build-and-test workflow explicitly runs when pull requests are opened, updated, or reopened
- document the intended PR triggers directly within the workflow configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f3bba7f88332b20b952948648173